### PR TITLE
Adding target _blank on social links to better user experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             <a class="navigation-link" href="https://blog.tsuru.io" title="Blog">Blog</a>
           </li>
           <li class="navigation-item">
-            <a class="navigation-link" href="https://github.com/tsuru" title="Code">Code</a>
+            <a class="navigation-link" href="https://github.com/tsuru" target="_blank" title="Code">Code</a>
           </li>
         </ul>
       </nav>
@@ -202,22 +202,22 @@
           </p>
           <ul class="social container">
             <li class="social-item column">
-              <a class="social-link" href="https://github.com/tsuru" title="Tsuru on GitHub">
+              <a class="social-link" href="https://github.com/tsuru" target="_blank" title="Tsuru on GitHub">
                 <i class="social-icon icon fa fa-github"></i> GitHub
               </a>
             </li>
             <li class="social-item column">
-              <a class="social-link" href="https://gitter.im/tsuru/tsuru" title="Tsuru on Gitter">
+              <a class="social-link" href="https://gitter.im/tsuru/tsuru" target="_blank" title="Tsuru on Gitter">
                 <i class="social-icon icon fa fa-comments"></i> Talk to us on Gitter
               </a>
             </li>
             <li class="social-item column">
-              <a class="social-link" href="https://twitter.com/tsurupaas" title="Tsuru on twitter">
+              <a class="social-link" href="https://twitter.com/tsurupaas" target="_blank" title="Tsuru on twitter">
                 <i class="social-icon icon fa fa-twitter"></i> Twitter
               </a>
             </li>
             <li class="social-item column">
-              <a class="social-link" href="https://groups.google.com/forum/?fromgroups#!forum/tsuru-users" title="Tsuru general mailing list">
+              <a class="social-link" href="https://groups.google.com/forum/?fromgroups#!forum/tsuru-users" target="_blank" title="Tsuru general mailing list">
                 <i class="social-icon icon fa fa-envelope"></i> General mailing list
               </a>
             </li>


### PR DESCRIPTION
Added target _blank for anchor tag on social links (gitter, github, twitter).
This way the user will not leave the website after clicking on a social media link, thus improving their experience.